### PR TITLE
Fix group_name from not existing ENV being wrongly interpreted

### DIFF
--- a/rootfs/smashbox/etc/smashbox.conf
+++ b/rootfs/smashbox/etc/smashbox.conf
@@ -24,7 +24,7 @@ oc_account_name=os.getenv("SMASHBOX_ACCOUNT_NAME", None)
 oc_number_test_users=3
 
 # name of the group used for testing
-oc_group_name=os.getenv("SMASHBOX_GROUP_NAME", None)
+oc_group_name=os.getenv("SMASHBOX_GROUP_NAME", "group_")
 
 # default number of groups for tests involving multiple groups (group number is appended to the oc_group_name)
 # this only applies to the tests involving multiple groups


### PR DESCRIPTION
port of #7 