### PR TITLE
Install submodule dependencies

### DIFF
--- a/rootfs/usr/local/bin/smash-wrapper
+++ b/rootfs/usr/local/bin/smash-wrapper
@@ -111,6 +111,8 @@ if [[ ! -d ${SMASHBOX_CLIENT_FOLDER} ]]; then
 fi
 
 pushd ${SMASHBOX_CLIENT_FOLDER}
+  git submodule update --init
+
   cmake \
     -DCMAKE_BUILD_TYPE="Debug" \
     -DCMAKE_INSTALL_LIBDIR=lib \


### PR DESCRIPTION
This should fix `zsync` errors in smashbox builds - https://drone.owncloud.com/owncloud/smashbox-testing/195/98

CC @DeepDiver1975 @tboerger @patrickjahns 